### PR TITLE
fix(web): resolve react-hooks/set-state-in-effect lint errors

### DIFF
--- a/web/src/components/AuthenticationGuard.tsx
+++ b/web/src/components/AuthenticationGuard.tsx
@@ -17,14 +17,14 @@ export function AuthenticationGuard({children}: AuthenticationGuardProps) {
     const navigate = useNavigate();
     const location = useLocation();
 
-    useEffect(() => {
-        let authCheckInterval: number;
+    const isPublicRoute = PUBLIC_ROUTES.includes(location.pathname as typeof PUBLIC_ROUTES[number]);
 
-        const isPublicRoute = PUBLIC_ROUTES.includes(location.pathname as typeof PUBLIC_ROUTES[number]);
+    useEffect(() => {
         if (isPublicRoute) {
-            setIsLoading(false);
             return;
         }
+
+        let authCheckInterval: number;
 
         async function checkAuthentication() {
             try {
@@ -85,9 +85,9 @@ export function AuthenticationGuard({children}: AuthenticationGuardProps) {
                 window.clearInterval(authCheckInterval);
             }
         };
-    }, [dispatch, navigate, location.pathname]);
+    }, [dispatch, navigate, location.pathname, isPublicRoute]);
 
-    if (isLoading) {
+    if (isLoading && !isPublicRoute) {
         return <div className="loading-spinner">Loading...</div>;
     }
 

--- a/web/src/components/WordModal.tsx
+++ b/web/src/components/WordModal.tsx
@@ -30,6 +30,20 @@ export function WordModal({
     const [error, setError] = useState<string>("");
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [isMobile, setIsMobile] = useState(window.innerWidth < 576);
+    const [wasShown, setWasShown] = useState(show);
+
+    // Reset form on open transition by adjusting state during render — see
+    // https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+    if (show !== wasShown) {
+        setWasShown(show);
+        if (show) {
+            setWordInput(word);
+            setNewWordInput(word);
+            setTranslationInput(translation);
+            setDescriptionInput(description);
+            setError("");
+        }
+    }
 
     // Handle window resize for responsive design
     useEffect(() => {
@@ -41,21 +55,17 @@ export function WordModal({
         return () => window.removeEventListener('resize', handleResize);
     }, []);
 
-    // Reset form when modal opens with new props
+    // Focus the appropriate input after the modal is shown
     useEffect(() => {
-        if (show) {
-            setWordInput(word);
-            setNewWordInput(word);
-            setTranslationInput(translation);
-            setDescriptionInput(description);
-            setError("");
-            const focusElement = action === 'add' ? "word-input" : "new-word-input";
-            const element = document.getElementById(focusElement);
-            if (element) {
-                (element as HTMLInputElement).focus();
-            }
+        if (!show) {
+            return;
         }
-    }, [show, word, translation, description, action]);
+        const focusElement = action === 'add' ? "word-input" : "new-word-input";
+        const element = document.getElementById(focusElement);
+        if (element) {
+            (element as HTMLInputElement).focus();
+        }
+    }, [show, action]);
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();

--- a/web/src/routes/Home.tsx
+++ b/web/src/routes/Home.tsx
@@ -50,10 +50,6 @@ export function Home() {
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    if (error !== "") {
-      setError("");
-    }
-
     client
       .findWords(qp)
       .then((r) => {
@@ -75,6 +71,7 @@ export function Home() {
           return;
         }
 
+        setError("");
         setWords(w);
       })
       .catch((e) => {
@@ -82,7 +79,6 @@ export function Home() {
         setError("Failed to fetch words");
         setWords(null);
       });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [qp, refetchTrigger]);
 
   useEffect(() => {


### PR DESCRIPTION
Avoid setState calls inside useEffect bodies that triggered cascading renders, per the new react-hooks/set-state-in-effect rule:

- AuthenticationGuard: hoist the public-route check out of the effect and gate the loading UI on it instead of toggling isLoading early.
- Home: clear the error banner inside the fetch success path rather than at the top of the effect.
- WordModal: reset form fields on the show transition by adjusting state during render (per React docs), splitting focus into its own effect.