### PR TITLE
ci: serialize docker builds to keep :latest in commit order

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,6 +16,10 @@ on:
 env:
   REGISTRY: ghcr.io
 
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build-bot:
     name: Build Bot Image


### PR DESCRIPTION
Adds a workflow-level concurrency group so concurrent pushes to main queue instead of racing. Without this, an older commit's build can finish after a newer one and overwrite :latest, leaving the registry out of sync with main.