### PR TITLE
feat: offer only conflict resolutions that change something

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,6 +254,13 @@ Word endpoints beyond the CRUD set:
   `update_only`) applies the answer. Which translation to keep needs no flag — the caller just
   sends whichever text the user chose
 
+The conflict question is only asked about things that would actually change, which is why the 409's
+`existing` carries `in_batch` alongside `guessed_streak`: a zero streak makes reset a no-op, and an
+already-batched word makes the batch half of `reset_and_batch` a no-op. `web/src/components/wordConflict.ts`
+turns those two facts into the set of buttons, so the three resolutions collapse to two (or to none —
+same text, zero streak, already batched, which the UI resolves silently with `update_only` instead of
+opening a dialog). Keep that logic in one place; it is shared by the dialog and the silent path.
+
 `GET /health` is registered **before** the auth middleware and is deliberately public. It returns
 `conf.BuildInfo` (`{"status", "version", "build_time"}`), which `main.go` fills from the
 `-ldflags`-stamped `Version`/`BuildTime` globals. The web navbar reads it to show the running

--- a/internal/api/words.go
+++ b/internal/api/words.go
@@ -18,6 +18,10 @@ type (
 		Description   string `json:"description"`
 		ToReview      bool   `json:"to_review"`
 		GuessedStreak int    `json:"guessed_streak,omitempty"`
+		// InBatch is read-only: it says whether the word is currently in the learning batch, which
+		// is what tells a caller resolving a conflict whether "add to the batch" would change
+		// anything.
+		InBatch bool `json:"in_batch"`
 		// OnConflict is only meaningful on create. Left empty, adding a word that already exists is
 		// refused with 409 and the existing entry, so the caller can ask the user what to do; set,
 		// it applies that answer.
@@ -93,6 +97,7 @@ func (h *WordsHandler) FindWords(c echo.Context) error {
 			Description:   word.Description,
 			ToReview:      word.ToReview,
 			GuessedStreak: word.GuessedStreak,
+			InBatch:       word.InBatch,
 		}
 	}
 
@@ -156,7 +161,7 @@ func (h *WordsHandler) CreateWord(c echo.Context) error {
 		}
 
 		// Report what is already stored so the caller can show the translation and the streak that
-		// an overwrite would discard.
+		// an overwrite would discard, and work out which resolutions would actually change anything.
 		return c.JSON(http.StatusConflict, echo.Map{
 			"error": "word already exists",
 			"existing": WordTranslation{
@@ -165,6 +170,7 @@ func (h *WordsHandler) CreateWord(c echo.Context) error {
 				Description:   existing.Description,
 				ToReview:      existing.ToReview,
 				GuessedStreak: existing.GuessedStreak,
+				InBatch:       existing.InBatch,
 			},
 		})
 	}

--- a/internal/api/words_create_test.go
+++ b/internal/api/words_create_test.go
@@ -75,6 +75,42 @@ func TestCreateWordDuplicateReportsConflict(t *testing.T) {
 	}
 }
 
+// The dialog only offers resolutions that would change something, and whether "add to the learning
+// batch" is one of them is not derivable from the streak: a word can sit in the batch at any streak.
+func TestCreateWordConflictReportsBatchMembership(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		inBatch bool
+	}{
+		{name: "batched", inBatch: true},
+		{name: "not batched", inBatch: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &stubWordsRepo{findWord: existingWord(dal.WordTranslation{
+				Word: "apple", Translation: "яблуко", GuessedStreak: 0, InBatch: tt.inBatch,
+			})}
+			h := api.NewWordsHandler(repo, testLogger())
+
+			c, rec := newRequest(t, "/words", `{"word":"apple","translation":"різновид яблука"}`)
+			if err := h.CreateWord(c); err != nil {
+				t.Fatalf("CreateWord: %v", err)
+			}
+
+			assertStatus(t, rec, http.StatusConflict)
+
+			var body struct {
+				Existing api.WordTranslation `json:"existing"`
+			}
+			if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if body.Existing.InBatch != tt.inBatch {
+				t.Errorf("existing in_batch = %v, want %v", body.Existing.InBatch, tt.inBatch)
+			}
+		})
+	}
+}
+
 func TestCreateWordAppliesConflictResolution(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/dal/models.go
+++ b/internal/dal/models.go
@@ -19,8 +19,11 @@ type (
 		Description   string
 		GuessedStreak int
 		ToReview      bool
-		CreatedAt     time.Time
-		UpdatedAt     time.Time
+		// InBatch reports whether the word is currently in the active learning batch, i.e. whether
+		// it is one of the words being asked about right now.
+		InBatch   bool
+		CreatedAt time.Time
+		UpdatedAt time.Time
 	}
 
 	Stats struct {

--- a/internal/dal/words.go
+++ b/internal/dal/words.go
@@ -65,37 +65,37 @@ func upsertWordTranslation(ctx context.Context, e execer, chatID int64, word, tr
 // inside inTx: *sql.Tx is not safe for concurrent use and the two queries would deadlock.
 func (r *SQLiteRepository) FindWordTranslations(ctx context.Context, chatID int64, filter WordTranslationsFilter) ([]WordTranslation, int, error) {
 	baseQuery := qb.Select().
-		From("word_translations").
-		Where(squirrel.Eq{"chat_id": chatID})
+		From("word_translations wt").
+		Where(squirrel.Eq{"wt.chat_id": chatID})
 
 	if filter.Word != "" {
 		// Search in both word and translation fields for SQLite compatibility
 		searchTerm := fmt.Sprintf("%%%s%%", strings.ToLower(filter.Word))
 		baseQuery = baseQuery.Where(
 			squirrel.Or{
-				squirrel.Expr("LOWER(word) LIKE ?", searchTerm),
-				squirrel.Expr("LOWER(translation) LIKE ?", searchTerm),
+				squirrel.Expr("LOWER(wt.word) LIKE ?", searchTerm),
+				squirrel.Expr("LOWER(wt.translation) LIKE ?", searchTerm),
 			},
 		)
 	}
 
 	if filter.ToReview {
-		baseQuery = baseQuery.Where(squirrel.Eq{"to_review": filter.ToReview})
+		baseQuery = baseQuery.Where(squirrel.Eq{"wt.to_review": filter.ToReview})
 	}
 
 	switch filter.Guessed {
 	case "", GuessedAll:
 	case GuessedLearned:
-		baseQuery = baseQuery.Where(squirrel.Expr("guessed_streak >= ?", r.streakLimit))
+		baseQuery = baseQuery.Where(squirrel.Expr("wt.guessed_streak >= ?", r.streakLimit))
 	case GuessedBatched:
-		baseQuery = baseQuery.Where("EXISTS (SELECT 1 FROM learning_batches lb WHERE lb.chat_id = word_translations.chat_id AND lb.word = word_translations.word)")
+		baseQuery = baseQuery.Where("EXISTS (SELECT 1 FROM learning_batches lb WHERE lb.chat_id = wt.chat_id AND lb.word = wt.word)")
 	case GuessedToLearn:
-		baseQuery = baseQuery.Where("guessed_streak = 0")
+		baseQuery = baseQuery.Where("wt.guessed_streak = 0")
 	}
 
 	selectQuery2 := baseQuery.
-		Columns("chat_id", "word", "translation", "COALESCE(description, '')", "guessed_streak", "to_review", "created_at", "updated_at").
-		OrderBy("word").
+		Columns(wordTranslationColumns()...).
+		OrderBy("wt.word").
 		Offset(filter.Offset).
 		Limit(filter.Limit)
 
@@ -277,11 +277,7 @@ func batchedWordTranslationsCount(ctx context.Context, e execer, chatID int64) (
 }
 
 func (r *SQLiteRepository) FindWordTranslation(ctx context.Context, chatID int64, word string) (*WordTranslation, error) {
-	query := qb.Select(
-		"wt.chat_id", "wt.word", "wt.translation",
-		"COALESCE(wt.description, '')", "wt.guessed_streak",
-		"wt.to_review", "wt.created_at", "wt.updated_at",
-	).
+	query := qb.Select(wordTranslationColumns()...).
 		From("word_translations wt").
 		Where(squirrel.Eq{"wt.chat_id": chatID, "wt.word": word})
 
@@ -305,11 +301,7 @@ func (r *SQLiteRepository) FindRandomWordTranslation(ctx context.Context, chatID
 	var query2 squirrel.SelectBuilder
 
 	if filter.Batched {
-		query2 = qb.Select(
-			"wt.chat_id", "wt.word", "wt.translation",
-			"COALESCE(wt.description, '')", "wt.guessed_streak",
-			"wt.to_review", "wt.created_at", "wt.updated_at",
-		).
+		query2 = qb.Select(wordTranslationColumns()...).
 			From("word_translations wt").
 			Join("learning_batches lb ON wt.chat_id = lb.chat_id AND wt.word = lb.word").
 			Where(squirrel.Eq{"wt.chat_id": chatID}).
@@ -323,11 +315,7 @@ func (r *SQLiteRepository) FindRandomWordTranslation(ctx context.Context, chatID
 			orderBy = "wt.last_reviewed_seq ASC"
 		}
 
-		query2 = qb.Select(
-			"wt.chat_id", "wt.word", "wt.translation",
-			"COALESCE(wt.description, '')", "wt.guessed_streak",
-			"wt.to_review", "wt.created_at", "wt.updated_at",
-		).
+		query2 = qb.Select(wordTranslationColumns()...).
 			From("word_translations wt").
 			Where(squirrel.Eq{"wt.chat_id": chatID}).
 			Where(squirrel.Expr("wt.guessed_streak "+filter.StreakLimitDirection.String()+" ?", filter.StreakLimit)).
@@ -378,6 +366,21 @@ func deleteFromLearningBatchGeGuessedStreak(ctx context.Context, e execer, chatI
 	return int(affected), nil
 }
 
+// wordTranslationColumns returns the column list hydrateWordTranslation scans, in order. Every query
+// that uses it must select from `word_translations wt`, since the columns are alias-qualified.
+//
+// Keep the two in sync: a query that hand-rolls its own column list will scan into the wrong fields
+// the next time one is added here. It is built per call rather than kept in a package variable so
+// that no caller can mutate the list every query shares.
+func wordTranslationColumns() []string {
+	return []string{
+		"wt.chat_id", "wt.word", "wt.translation",
+		"COALESCE(wt.description, '')", "wt.guessed_streak",
+		"wt.to_review", "wt.created_at", "wt.updated_at",
+		"EXISTS (SELECT 1 FROM learning_batches blb WHERE blb.chat_id = wt.chat_id AND blb.word = wt.word)",
+	}
+}
+
 func hydrateWordTranslation(row interface {
 	Scan(dest ...interface{}) error
 }) (*WordTranslation, error) {
@@ -391,6 +394,7 @@ func hydrateWordTranslation(row interface {
 		&wt.ToReview,
 		&wt.CreatedAt,
 		&wt.UpdatedAt,
+		&wt.InBatch,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("scan word translation: %w", err)

--- a/internal/dal/words_test.go
+++ b/internal/dal/words_test.go
@@ -253,3 +253,58 @@ func TestCreateWordTranslationRefusesExistingWord(t *testing.T) {
 		t.Errorf("streak = %d, want the untouched 12", got.GuessedStreak)
 	}
 }
+
+// The conflict dialog decides whether "add to the learning batch" is worth offering, so a read has
+// to say where the word currently is, not just what its streak is.
+func TestFindWordTranslationReportsBatchMembership(t *testing.T) {
+	ctx := context.Background()
+	r := dal.NewTestRepo(t)
+
+	r.AddWord("batched", 3)
+	r.AddWord("loose", 3)
+	r.SeedBatch("batched")
+
+	for _, tt := range []struct {
+		word string
+		want bool
+	}{
+		{word: "batched", want: true},
+		{word: "loose", want: false},
+	} {
+		got, err := r.FindWordTranslation(ctx, dal.TestChatID, tt.word)
+		if err != nil {
+			t.Fatalf("FindWordTranslation(%q): %v", tt.word, err)
+		}
+		if got.InBatch != tt.want {
+			t.Errorf("%q InBatch = %v, want %v", tt.word, got.InBatch, tt.want)
+		}
+	}
+}
+
+func TestFindWordTranslationsReportBatchMembership(t *testing.T) {
+	ctx := context.Background()
+	r := dal.NewTestRepo(t)
+
+	r.AddWord("batched", 3)
+	r.AddWord("loose", 3)
+	r.SeedBatch("batched")
+
+	got, _, err := r.FindWordTranslations(ctx, dal.TestChatID, dal.WordTranslationsFilter{Limit: 10})
+	if err != nil {
+		t.Fatalf("FindWordTranslations: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d words, want 2", len(got))
+	}
+
+	inBatch := make(map[string]bool, len(got))
+	for _, wt := range got {
+		inBatch[wt.Word] = wt.InBatch
+	}
+	if !inBatch["batched"] {
+		t.Error("batched word reported as outside the batch")
+	}
+	if inBatch["loose"] {
+		t.Error("unbatched word reported as batched")
+	}
+}

--- a/web/src/api/client.tsx
+++ b/web/src/api/client.tsx
@@ -59,6 +59,8 @@ export interface Word {
     description?: string;
     to_review?: boolean;
     guessed_streak?: number;
+    /** Read only: whether the word is currently in the active learning batch. */
+    in_batch?: boolean;
     /** Create only. Omitted, a duplicate is refused with 409 instead of overwritten. */
     on_conflict?: ConflictResolution;
 }

--- a/web/src/components/WordConflictModal.tsx
+++ b/web/src/components/WordConflictModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Alert, Badge, Button, Form, Modal } from "react-bootstrap";
 import client, { type ConflictResolution, type Word } from "../api/client.tsx";
+import { conflictChoices, conflictExplanation, resolutionActions } from "./wordConflict.ts";
 
 interface WordConflictModalProps {
   show: boolean;
@@ -42,16 +43,15 @@ export function WordConflictModal({
     }
   }
 
-  const differs =
-    existing.translation !== incoming.translation ||
-    (existing.description || "") !== (incoming.description || "");
+  const choices = conflictChoices(existing, incoming);
+  const { textDiffers } = choices;
 
   const submit = async (onConflict: ConflictResolution) => {
     setError("");
     setIsSubmitting(true);
 
     // Whichever text the user picked is simply what we send; the server writes it verbatim.
-    const chosen = !differs || choice === "incoming" ? incoming : existing;
+    const chosen = !textDiffers || choice === "incoming" ? incoming : existing;
 
     try {
       const response = await client.createWord({
@@ -96,9 +96,15 @@ export function WordConflictModal({
               {streak}/{streakLimit}
             </Badge>
           )}
+          {existing.in_batch && (
+            <>
+              {" "}
+              <Badge bg="info">In learning batch</Badge>
+            </>
+          )}
         </p>
 
-        {differs ? (
+        {textDiffers ? (
           <Form.Group className="mb-3">
             <Form.Label className="fw-semibold">Which translation should be kept?</Form.Label>
             <Form.Check
@@ -138,11 +144,7 @@ export function WordConflictModal({
           </p>
         )}
 
-        <p className="text-muted small mb-0">
-          If you were adding this word again because you had forgotten it, reset the streak. A reset
-          word is no longer picked for reviews, so add it to the learning batch as well to be asked
-          about it again soon; otherwise it waits until a batch refill picks it up.
-        </p>
+        <p className="text-muted small mb-0">{conflictExplanation(choices)}</p>
 
         {error && (
           <Alert variant="danger" className="mt-3 mb-0">
@@ -151,30 +153,17 @@ export function WordConflictModal({
         )}
       </Modal.Body>
       <Modal.Footer className="d-flex flex-column gap-2">
-        <Button
-          variant="warning"
-          onClick={() => submit("reset_and_batch")}
-          disabled={isSubmitting}
-          className="w-100"
-        >
-          Reset and add to learning batch
-        </Button>
-        <Button
-          variant="outline-warning"
-          onClick={() => submit("reset_only")}
-          disabled={isSubmitting}
-          className="w-100"
-        >
-          Reset only
-        </Button>
-        <Button
-          variant="outline-primary"
-          onClick={() => submit("update_only")}
-          disabled={isSubmitting}
-          className="w-100"
-        >
-          Update translation only (keep streak)
-        </Button>
+        {resolutionActions(choices).map((action) => (
+          <Button
+            key={action.resolution}
+            variant={action.variant}
+            onClick={() => submit(action.resolution)}
+            disabled={isSubmitting}
+            className="w-100"
+          >
+            {action.label}
+          </Button>
+        ))}
         <Button variant="secondary" onClick={onBack} disabled={isSubmitting} className="w-100">
           Back
         </Button>

--- a/web/src/components/WordModal.tsx
+++ b/web/src/components/WordModal.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { Modal, Button, Form, Alert } from "react-bootstrap";
 import client, { type Word, type WordConflictResponse } from "../api/client.tsx";
 import { WordConflictModal } from "./WordConflictModal.tsx";
+import { isTrivialConflict } from "./wordConflict.ts";
 
 export type WordModalAction = 'add' | 'edit';
 
@@ -119,14 +120,30 @@ export function WordModal({
             // rather than silently overwriting it.
             if (response.status === 409) {
                 const body: WordConflictResponse = await response.json();
-                setConflict({
-                    existing: body.existing,
-                    incoming: {
-                        word: wordInput,
-                        translation: translationInput,
-                        description: descriptionInput,
-                    },
-                });
+                const incoming: Word = {
+                    word: wordInput,
+                    translation: translationInput,
+                    description: descriptionInput,
+                };
+
+                // ...unless there is no progress to overwrite and nothing about the entry would
+                // change. Asking would offer only buttons that all do the same thing.
+                if (isTrivialConflict(body.existing, incoming)) {
+                    const resolved = await client.createWord({
+                        ...incoming,
+                        on_conflict: "update_only",
+                    });
+                    if (resolved.ok) {
+                        onSuccess();
+                        onHide();
+                        return;
+                    }
+                    const resolveError = await resolved.json().catch(() => ({}));
+                    setError(resolveError.error ?? "Failed to add word");
+                    return;
+                }
+
+                setConflict({ existing: body.existing, incoming });
                 return;
             }
 

--- a/web/src/components/wordConflict.ts
+++ b/web/src/components/wordConflict.ts
@@ -1,0 +1,103 @@
+import type { ConflictResolution, Word } from "../api/client.tsx";
+
+/**
+ * What re-adding an existing word could still change about it.
+ *
+ * Only these decide what the user is asked. A resolution that would change nothing is not worth a
+ * button: resetting a streak that is already zero, or batching a word that is already batched, does
+ * nothing the user could notice.
+ */
+export interface ConflictChoices {
+  /** There is progress a reset would discard. */
+  canReset: boolean;
+  /** The word is outside the learning batch, so adding it back changes when it comes up. */
+  canBatch: boolean;
+  /** The text differs from what is stored, so there is something to pick between. */
+  textDiffers: boolean;
+}
+
+export function conflictChoices(existing: Word, incoming: Word): ConflictChoices {
+  return {
+    canReset: (existing.guessed_streak || 0) > 0,
+    canBatch: !existing.in_batch,
+    textDiffers:
+      existing.translation !== incoming.translation ||
+      (existing.description || "") !== (incoming.description || ""),
+  };
+}
+
+/**
+ * True when re-adding the word is a no-op: same text, nothing to reset, already batched. The caller
+ * should just apply it instead of opening a dialog whose every button changes nothing.
+ */
+export function isTrivialConflict(existing: Word, incoming: Word): boolean {
+  const { canReset, canBatch, textDiffers } = conflictChoices(existing, incoming);
+  return !canReset && !canBatch && !textDiffers;
+}
+
+export interface ResolutionAction {
+  resolution: ConflictResolution;
+  label: string;
+  variant: string;
+}
+
+/**
+ * The buttons to offer, one per outcome that is actually distinct.
+ *
+ * `reset_and_batch` doubles as plain "add to the batch" once the streak is already zero, and
+ * `reset_only` as plain "reset" once the word is already batched — in both cases the other half of
+ * the resolution is a no-op, so it needs no button of its own.
+ */
+export function resolutionActions({ canReset, canBatch }: ConflictChoices): ResolutionAction[] {
+  if (canReset && canBatch) {
+    return [
+      {
+        resolution: "reset_and_batch",
+        label: "Reset streak and add to learning batch",
+        variant: "warning",
+      },
+      { resolution: "reset_only", label: "Reset streak only", variant: "outline-warning" },
+      { resolution: "update_only", label: "Keep the current streak", variant: "outline-primary" },
+    ];
+  }
+  if (canReset) {
+    return [
+      { resolution: "reset_only", label: "Reset streak", variant: "warning" },
+      { resolution: "update_only", label: "Keep the current streak", variant: "outline-primary" },
+    ];
+  }
+  if (canBatch) {
+    return [
+      { resolution: "reset_and_batch", label: "Add to learning batch", variant: "warning" },
+      { resolution: "update_only", label: "Leave it out of the batch", variant: "outline-primary" },
+    ];
+  }
+  // Nothing about the progress can change, so the only thing being saved is the new text.
+  return [{ resolution: "update_only", label: "Save translation", variant: "primary" }];
+}
+
+export function conflictExplanation({ canReset, canBatch }: ConflictChoices): string {
+  if (canReset && canBatch) {
+    return (
+      "Reset the streak if you are adding this word again because you had forgotten it. A reset " +
+      "word is no longer picked for reviews, so add it to the learning batch as well to be asked " +
+      "about it again soon; otherwise it waits until a batch refill picks it up."
+    );
+  }
+  if (canReset) {
+    return (
+      "Reset the streak if you are adding this word again because you had forgotten it. It is " +
+      "already in the learning batch, so it will keep coming up either way."
+    );
+  }
+  if (canBatch) {
+    return (
+      "Its streak is already zero, so there is nothing to reset. Add it to the learning batch to " +
+      "be asked about it again soon; otherwise it waits until a batch refill picks it up."
+    );
+  }
+  return (
+    "Its streak is already zero and it is already in the learning batch, so only the translation " +
+    "changes."
+  );
+}

--- a/web/src/routes/Home.tsx
+++ b/web/src/routes/Home.tsx
@@ -449,7 +449,8 @@ export function Home() {
                             <Button
                               variant="link"
                               size="sm"
-                              className="p-1"
+                              className="p-1 text-primary"
+                              title="Edit word"
                               onClick={() => {
                                 setModalState({
                                   show: true,
@@ -485,7 +486,8 @@ export function Home() {
                             <Button
                               variant="link"
                               size="sm"
-                              className="p-1"
+                              className="p-1 text-danger"
+                              title="Delete word"
                               onClick={() => handleDeleteWord(item.word)}
                             >
                               <Trash />


### PR DESCRIPTION
Report in_batch alongside guessed_streak so re-adding an existing word asks only about outcomes that differ: reset collapses away at a zero streak, batching at an already-batched word, and a no-op conflict is applied silently instead of opening a dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)